### PR TITLE
Fix/carousel slides validation issue 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- fix(blocks): remove required validation from carousel slides field ([#2](https://github.com/iamgerwin/nova-reusable-blocks/issues/2))
+  - Carousel Banner block is now truly optional within a Section
+  - Users can submit forms without adding carousel content
+  - Individual slide images remain required when slides are created
+
 ## [0.0.2] - 2025-10-15
 
 ### Added

--- a/src/Blocks/CarouselBannerBlock.php
+++ b/src/Blocks/CarouselBannerBlock.php
@@ -30,7 +30,6 @@ class CarouselBannerBlock
                 Flexible::make('Slides', 'slides')
                     ->addLayout(...CarouselSlideItem::make())
                     ->button('Add Slide')
-                    ->rules('required')
                     ->help('Add and configure individual slides with images, text, and CTAs'),
 
                 Text::make('Banner Title', 'banner_title')


### PR DESCRIPTION
Issue Fixed
Bug #2: Carousel Banner slides field should not be required when block is not used

Changes Made

1. Fixed the validation bug (fix(blocks): remove required validation from carousel slides field)
◦  Removed ->rules('required') from Slides flexible field in CarouselBannerBlock.php (line 33)
◦  Makes Carousel Banner block truly optional within a Section
◦  Individual slide images remain required when slides are actually created
2. Updated documentation (docs: update CHANGELOG for carousel slides validation fix)
◦  Added [Unreleased] section to CHANGELOG.md
◦  Documented the fix with issue reference
◦  Explained the changes and their impact

Quality Checks ✅
•  ✅ All tests pass (20 passed, 5 skipped)
•  ✅ PHPStan level 9 - no errors
•  ✅ PSR-12 code formatting compliant
•  ✅ Conventional Commits format followed
•  ✅ No automated tool references in commits

Branch & PR Status
•  ✅ Branch created: fix/carousel-slides-validation-issue-2
•  ✅ 2 granular commits pushed to GitHub
•  ✅ Branch pushed to origin
•  🌐 PR creation page opened in browser

Expected Behavior After Fix

| Scenario | Before | After |
|----------|--------|-------|
| Submit form without blocks | ❌ Error | ✅ Success |
| Add Carousel block with no slides | ❌ Error | ✅ Success |
| Add slide without image | ❌ Error | ❌ Error (correct) |

Next Steps

The PR creation page is now open in your browser at:
**https://github.com/iamgerwin/nova-reusable-blocks/pull/new/fix/carousel-slides-validation-issue-2**

Simply:
1. Copy the content from .github/PR_DESCRIPTION.md 
2. Paste it into the PR description field
3. Click "Create Pull Request"

The PR will automatically:
•  Reference and close issue #2 when merged
•  Show the 2 granular commits
•  Display the validation fix changes